### PR TITLE
Allow GitCommands to have extra commands added via extension functions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 buildscript {
     repositories {
@@ -14,11 +13,7 @@ buildscript {
 plugins {
     base
     kotlin("jvm") version Versions.kotlin apply false
-    id(Plugins.detekt) version Versions.detekt
-    id(Plugins.dokka) version Versions.dokka apply false
     id(Plugins.gradleVersions) version Versions.versionsPlugin
-    id(Plugins.ktlint) version Versions.ktlintPlugin
-    id(Plugins.ktlintIdea) version Versions.ktlintPlugin
 }
 
 allprojects {
@@ -39,31 +34,6 @@ allprojects {
         }
         testLogging {
             events("passed", "skipped", "failed")
-        }
-    }
-}
-
-subprojects {
-    apply(plugin = Plugins.detekt)
-    apply(plugin = Plugins.ktlint)
-    apply(plugin = Plugins.ktlintIdea)
-
-    detekt {
-        toolVersion = Versions.detekt
-        input = files(
-            "src/main/kotlin",
-            "src/test/kotlin"
-        )
-        parallel = true
-        config = files("${rootProject.projectDir}/config/detekt/detekt.yml")
-        buildUponDefaultConfig = true
-    }
-
-    ktlint {
-        version.set(Versions.ktlint)
-        reporters.set(setOf(ReporterType.PLAIN, ReporterType.CHECKSTYLE))
-        filter {
-            include("**/src/**/kotlin/**")
         }
     }
 }

--- a/sample/src/main/kotlin/com/lordcodes/turtle/sample/Main.kt
+++ b/sample/src/main/kotlin/com/lordcodes/turtle/sample/Main.kt
@@ -1,5 +1,6 @@
 package com.lordcodes.turtle.sample
 
+import com.lordcodes.turtle.GitCommands
 import com.lordcodes.turtle.shellRun
 
 /**
@@ -7,9 +8,13 @@ import com.lordcodes.turtle.shellRun
  */
 fun main() {
     shellRun {
+        println(git.gitAuthorName())
+
         command("mkdir", listOf("Test"))
         command("mkdir", listOf("Test2"))
         command("rm", listOf("-rf", "BLAH"))
         command("rm", listOf("-rf", "Test"))
     }
 }
+
+fun GitCommands.gitAuthorName() = gitCommand(listOf("--no-pager", "show", "-s", "--format=%an"))

--- a/sample/src/main/kotlin/com/lordcodes/turtle/sample/Main.kt
+++ b/sample/src/main/kotlin/com/lordcodes/turtle/sample/Main.kt
@@ -3,9 +3,6 @@ package com.lordcodes.turtle.sample
 import com.lordcodes.turtle.GitCommands
 import com.lordcodes.turtle.shellRun
 
-/**
- * Run the sample
- */
 fun main() {
     shellRun {
         println(git.gitAuthorName())

--- a/turtle/build.gradle.kts
+++ b/turtle/build.gradle.kts
@@ -2,10 +2,14 @@
 
 import com.novoda.gradle.release.PublishExtension
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 plugins {
     kotlin("jvm")
-    id(Plugins.dokka)
+    id(Plugins.detekt) version Versions.detekt
+    id(Plugins.dokka) version Versions.dokka
+    id(Plugins.ktlint) version Versions.ktlintPlugin
+    id(Plugins.ktlintIdea) version Versions.ktlintPlugin
 }
 
 dependencies {
@@ -27,6 +31,25 @@ val dokka by tasks.getting(DokkaTask::class) {
         dir = "./"
         url = "https://github.com/lordcodes/turtle/blob/master/"
         suffix = "#L"
+    }
+}
+
+detekt {
+    toolVersion = Versions.detekt
+    input = files(
+        "src/main/kotlin",
+        "src/test/kotlin"
+    )
+    parallel = true
+    config = files("${rootProject.projectDir}/config/detekt/detekt.yml")
+    buildUponDefaultConfig = true
+}
+
+ktlint {
+    version.set(Versions.ktlint)
+    reporters.set(setOf(ReporterType.PLAIN, ReporterType.CHECKSTYLE))
+    filter {
+        include("**/src/**/kotlin/**")
     }
 }
 

--- a/turtle/src/main/kotlin/com/lordcodes/turtle/FileCommands.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/FileCommands.kt
@@ -19,7 +19,7 @@ class FileCommands internal constructor(
      * @throws [ShellRunException] Running the command produced error output.
      */
     @Suppress("unused")
-    fun openFile(path: File) = openFile(path.toString())
+    fun openFile(path: File): String = openFile(path.toString())
 
     /**
      * Open a file using its default application.
@@ -32,7 +32,7 @@ class FileCommands internal constructor(
      * @throws [ShellRunException] Running the command produced error output.
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    fun openFile(path: String) = shell.command("open", listOf(path))
+    fun openFile(path: String): String = shell.command("open", listOf(path))
 
     /**
      * Open an application by name.
@@ -45,7 +45,7 @@ class FileCommands internal constructor(
      * @throws [ShellRunException] Running the command produced error output.
      */
     @Suppress("unused")
-    fun openApplication(name: String) = shell.command("open", listOf("-a", name))
+    fun openApplication(name: String): String = shell.command("open", listOf("-a", name))
 
     /**
      * Create a symbolic link at a given path, that links back to a different location.
@@ -58,7 +58,7 @@ class FileCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    fun createSymlink(targetPath: File, linkPath: File) =
+    fun createSymlink(targetPath: File, linkPath: File): String =
         createSymlink(targetPath.toString(), linkPath.toString())
 
     /**
@@ -72,7 +72,7 @@ class FileCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    fun createSymlink(targetPath: String, linkPath: String) =
+    fun createSymlink(targetPath: String, linkPath: String): String =
         shell.command("ln", listOf("-s", targetPath, linkPath))
 
     /**
@@ -85,7 +85,7 @@ class FileCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    fun readSymlink(linkPath: File) = readSymlink(linkPath.toString())
+    fun readSymlink(linkPath: File): String = readSymlink(linkPath.toString())
 
     /**
      * Read the target path of a symbolic link.
@@ -97,5 +97,5 @@ class FileCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    fun readSymlink(linkPath: String) = shell.command("readlink", listOf(linkPath))
+    fun readSymlink(linkPath: String): String = shell.command("readlink", listOf(linkPath))
 }

--- a/turtle/src/main/kotlin/com/lordcodes/turtle/GitCommands.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/GitCommands.kt
@@ -17,7 +17,7 @@ class GitCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    fun gitInit() = gitCommand(listOf("init"))
+    fun gitInit(): String = gitCommand(listOf("init"))
 
     /**
      * Get the working tree status of a Git repository. The status can signify if there are any uncommitted changes.
@@ -27,7 +27,7 @@ class GitCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    fun status() = gitCommand(listOf("status", "--porcelain"))
+    fun status(): String = gitCommand(listOf("status", "--porcelain"))
 
     /**
      * Stage any new, modified or deleted files, to be included in the next commit.
@@ -37,7 +37,7 @@ class GitCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    fun addAll() = gitCommand(listOf("add", "--all"))
+    fun addAll(): String = gitCommand(listOf("add", "--all"))
 
     /**
      * Create a Git commit with the given commit message. Any modified or deleted files will also be staged and
@@ -50,7 +50,7 @@ class GitCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    fun commit(message: String) = gitCommand(listOf("commit", "-a", "-m", message, "--quiet"))
+    fun commit(message: String): String = gitCommand(listOf("commit", "-a", "-m", message, "--quiet"))
 
     /**
      * Create a Git commit with the given commit message. Any new, modified or deleted files will also be staged and
@@ -137,7 +137,7 @@ class GitCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    fun clone(repositoryUrl: URL, destination: File? = null) =
+    fun clone(repositoryUrl: URL, destination: File? = null): String =
         clone(repositoryUrl.toString(), destination?.toString())
 
     /**
@@ -169,7 +169,7 @@ class GitCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    fun addTag(tagName: String, message: String) = gitCommand(listOf("tag", "-a", tagName, "-m", message))
+    fun addTag(tagName: String, message: String): String = gitCommand(listOf("tag", "-a", tagName, "-m", message))
 
     /**
      * Push the given Git tag.
@@ -181,7 +181,7 @@ class GitCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    fun pushTag(tagName: String) = gitCommand(listOf("push", "origin", tagName))
+    fun pushTag(tagName: String): String = gitCommand(listOf("push", "origin", tagName))
 
     /**
      * Get the current Git branch name.
@@ -191,8 +191,17 @@ class GitCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    fun currentBranch() = gitCommand(listOf("rev-parse", "--abbrev-ref", "HEAD"))
+    fun currentBranch(): String = gitCommand(listOf("rev-parse", "--abbrev-ref", "HEAD"))
 
-    private fun gitCommand(arguments: List<String>) =
-        shell.command("git", arguments)
+    /**
+     * Run a Git command with the specified arguments.
+     *
+     * @param [arguments] The arguments to pass to the Git command.
+     *
+     * @return [String] The output of running the command.
+     *
+     * @throws [ShellFailedException] There was an issue running the command.
+     * @throws [ShellRunException] Running the command produced error output.
+     */
+    fun gitCommand(arguments: List<String>): String = shell.command("git", arguments)
 }

--- a/turtle/src/main/kotlin/com/lordcodes/turtle/Shell.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/Shell.kt
@@ -16,7 +16,7 @@ import java.io.File
  * @throws [ShellFailedException] There was an issue running one of the commands.
  * @throws [ShellRunException] Running one of the commands produced error output.
  */
-fun shellRun(workingDirectory: File? = null, script: ShellScript.() -> String) =
+fun shellRun(workingDirectory: File? = null, script: ShellScript.() -> String): String =
     ShellScript(workingDirectory).script()
 
 /**
@@ -32,5 +32,5 @@ fun shellRun(workingDirectory: File? = null, script: ShellScript.() -> String) =
  * @throws [ShellFailedException] There was an issue running the command.
  * @throws [ShellRunException] Running the command produced error output.
  */
-fun shellRun(command: String, arguments: List<String> = listOf(), workingDirectory: File? = null) =
+fun shellRun(command: String, arguments: List<String> = listOf(), workingDirectory: File? = null): String =
     shellRun(workingDirectory) { command(command, arguments) }

--- a/turtle/src/main/kotlin/com/lordcodes/turtle/ShellScript.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/ShellScript.kt
@@ -68,7 +68,9 @@ class ShellScript internal constructor(workingDirectory: File? = null) {
      *
      * @param [path] The path to set the working directory to.
      */
-    fun changeWorkingDirectory(path: String) = changeWorkingDirectory(File(path))
+    fun changeWorkingDirectory(path: String) {
+        changeWorkingDirectory(File(path))
+    }
 
     /**
      * Change the working directory for subsequent shell commands.


### PR DESCRIPTION
By making the gitCommand function public, users of turtle can add
extension functions to GitCommands and then use these commands within
shellRun when calling 'git' just like the built-in git commands.

Also, specify return types on all public functions.