### PR TITLE
Access output streams and exit code

### DIFF
--- a/turtle/src/main/kotlin/com/lordcodes/turtle/ProcessOutput.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/ProcessOutput.kt
@@ -1,0 +1,16 @@
+package com.lordcodes.turtle
+
+import java.io.InputStream
+
+/**
+ * Output of running a shell command.
+ *
+ * @property [exitCode] The exit code of the process. By convention, the value {@code 0} indicates normal termination.
+ * @property [standardOutput] The standard output produced by running a command or series of commands.
+ * @property [standardError] The error output produced by running a command or series of commands.
+ */
+data class ProcessOutput(
+    val exitCode: Int,
+    val standardOutput: InputStream,
+    val standardError: InputStream
+)

--- a/turtle/src/test/kotlin/com/lordcodes/turtle/ShellScriptTest.kt
+++ b/turtle/src/test/kotlin/com/lordcodes/turtle/ShellScriptTest.kt
@@ -58,6 +58,13 @@ internal class ShellScriptTest {
     }
 
     @Test
+    fun commandStreaming() {
+        val output = ShellScript().commandStreaming("echo", listOf("Hello world!"))
+
+        assertThat(output.standardOutput.bufferedReader().readText().trim()).isEqualTo("Hello world!")
+    }
+
+    @Test
     fun changeWorkingDirectory_stringPath(@TempDir temporaryFolder: File) {
         val testFile = File(temporaryFolder, "testFile")
         testFile.createNewFile()


### PR DESCRIPTION
<!-- Thanks for your contribution to *Turtle*! Please check the boxes below before opening the pull request, you do this by putting an x in the box like this: [x]. Thank you! -->

### Checklist
- [x] I've read the [guide for contributing](https://github.com/lordcodes/turtle/blob/master/CONTRIBUTING.md).
- [x] I've checked there are no other [open pull requests](https://github.com/lordcodes/turtle/pulls) for the same change.
- [x] I've formatted all code changes with `./gradlew lcCodeFormat`.
- [x] I've ran all checks with `./gradlew lcChecks`.
- [x] I've updated documentation if needed.
- [x] I've added or updated tests for changes.

### Reason for change
<!-- If the pull request fixes an open issue, please include a link to the issue here. -->
<!-- Please explain why the change is required and the problem it solves. -->
Currently command output can only be obtained as a String, requiring the whole command to complete for anything is received. This PR offers the InputStreams for standard output and error as well as the exit code. This allows the caller to choose how they are consumed.
