### PR TITLE
Shellscript cannot be given as a constructor parameter due to the fac…

### DIFF
--- a/turtle/src/main/kotlin/com/lordcodes/turtle/ShellScript.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/ShellScript.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit
 /**
  * Create and run either built-in or specified shell commands.
  */
-class ShellScript internal constructor(workingDirectory: File? = null) {
+open class ShellScript internal constructor(workingDirectory: File? = null) {
     private val processBuilder = ProcessBuilder(listOf())
         .directory(workingDirectory)
         .redirectOutput(ProcessBuilder.Redirect.PIPE)


### PR DESCRIPTION
…t that it isn't open and has an internal constructor.

This makes testing a layer which uses Shellscript (albeit a mock-variant) impossible. By making Shellscript 'open', this issue is circumvented. This results ShellScript being mockable and usable in (unit)-tests which don't focus on ShellScript.

<!-- Thanks for your contribution to *Turtle*! Please check the boxes below before opening the pull request, you do this by putting an x in the box like this: [x]. Thank you! -->

### Checklist
- [x] I've read the [guide for contributing](https://github.com/lordcodes/turtle/blob/master/CONTRIBUTING.md).
- [x] I've checked there are no other [open pull requests](https://github.com/lordcodes/turtle/pulls) for the same change.
- [x] I've formatted all code changes with `./gradlew lcCodeFormat`.
- [x] I've ran all checks with `./gradlew lcChecks`.
- [x] I've updated documentation if needed.
- [x] I've added or updated tests for changes.

### Reason for change
https://github.com/lordcodes/turtle/issues/97
See description

### Description
Shellscript cannot be given as a constructor parameter due to the fact that it isn't open and has an internal constructor. 

This makes testing a layer which uses Shellscript (albeit a mock-variant) impossible. By making Shellscript 'open', this issue is circumvented. This results ShellScript being mockable and usable in (unit)-tests which don't focus on ShellScript. 


