### PR TITLE
Make ShellScript constructor accessible

### DIFF
--- a/turtle/src/main/kotlin/com/lordcodes/turtle/ShellScript.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/ShellScript.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit
 /**
  * Create and run either built-in or specified shell commands.
  */
-class ShellScript internal constructor(workingDirectory: File? = null) {
+class ShellScript constructor(workingDirectory: File? = null) {
     private val processBuilder = ProcessBuilder(listOf())
         .directory(workingDirectory)
         .redirectOutput(ProcessBuilder.Redirect.PIPE)


### PR DESCRIPTION
<!-- Thanks for your contribution to *Turtle*! Please check the boxes below before opening the pull request, you do this by putting an x in the box like this: [x]. Thank you! -->

### Checklist
- [x] I've read the [guide for contributing](https://github.com/lordcodes/turtle/blob/master/CONTRIBUTING.md).
- [x] I've checked there are no other [open pull requests](https://github.com/lordcodes/turtle/pulls) for the same change.
- [x] I've formatted all code changes with `./gradlew lcCodeFormat`.
- [x] I've ran all checks with `./gradlew lcChecks`.
- [x] I've updated documentation if needed.
- [x] I've added or updated tests for changes.

### Reason for change
<!-- If the pull request fixes an open issue, please include a link to the issue here. -->
<!-- Please explain why the change is required and the problem it solves. -->

Allow consumers of the library to create ShellScript instances, so that they aren't forced to use it only via the 'shellRun' function. This can be useful for creating a wrapper class around ShellScript for separation of concerns or to make code more testable.

### Description
<!-- Please describe the changes you have made, providing as much detail as possible and including how the changes were tested. -->

Make ShellScript constructor public instead of internal.

Relates to #97
