### PR TITLE
GH-115: Multiplatform open command

### DIFF
--- a/turtle/src/main/kotlin/com/lordcodes/turtle/FileCommands.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/FileCommands.kt
@@ -22,7 +22,7 @@ class FileCommands internal constructor(
     fun open(url: String): String = shell.multiplatform(
         mac = { command("open", listOf(url)) },
         linux = { command("xdg-open", listOf(url)) },
-        windows = { command("cmd.exe", listOf("/c", "start", url)) }
+        windows = { command("cmd.exe", listOf("/c", "start", url)) },
     )
 
     /**

--- a/turtle/src/main/kotlin/com/lordcodes/turtle/FileCommands.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/FileCommands.kt
@@ -9,6 +9,23 @@ class FileCommands internal constructor(
     private val shell: ShellScript,
 ) {
     /**
+     * Open a [url] using its default application. This URL can be a file path or web URL.
+     *
+     * @param [url] The URL to open, file path or web URL.
+     *
+     * @return [String] The output of running the command.
+     *
+     * @throws [ShellFailedException] There was an issue running the command.
+     * @throws [ShellRunException] Running the command produced error output.
+     */
+    @Suppress("unused", "MemberVisibilityCanBePrivate")
+    fun open(url: String): String = shell.multiplatform(
+        mac = { command("open", listOf(url)) },
+        linux = { command("xdg-open", listOf(url)) },
+        windows = { command("cmd.exe", listOf("/c", "start", url)) }
+    )
+
+    /**
      * Open a file at [path] using its default application, returning any output as a [String].
      *
      * @param [path] The file to open.
@@ -18,8 +35,8 @@ class FileCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    @Suppress("unused")
-    fun openFile(path: File): String = openFile(path.toString())
+    @Suppress("unused", "MemberVisibilityCanBePrivate")
+    fun openFile(path: File): String = open(path.toString())
 
     /**
      * Open a file at [path] using its default application, returning any output as a [String].
@@ -31,8 +48,8 @@ class FileCommands internal constructor(
      * @throws [ShellFailedException] There was an issue running the command.
      * @throws [ShellRunException] Running the command produced error output.
      */
-    @Suppress("MemberVisibilityCanBePrivate")
-    fun openFile(path: String): String = shell.command("open", listOf(path))
+    @Suppress("unused")
+    fun openFile(path: String): String = open(path)
 
     /**
      * Open an application by [name], returning any output as a [String].

--- a/turtle/src/main/kotlin/com/lordcodes/turtle/ShellScript.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/ShellScript.kt
@@ -120,7 +120,7 @@ class ShellScript constructor(
     internal fun multiplatform(
         mac: ShellScript.() -> String = { "Not implemented!" },
         linux: ShellScript.() -> String = { "Not implemented!" },
-        windows: ShellScript.() -> String = { "Not implemented!" }
+        windows: ShellScript.() -> String = { "Not implemented!" },
     ): String {
         val osName = System.getProperty("os.name")
         return when {

--- a/turtle/src/main/kotlin/com/lordcodes/turtle/ShellScript.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/ShellScript.kt
@@ -117,6 +117,19 @@ class ShellScript constructor(
         return outputText.trim()
     }
 
+    internal fun multiplatform(
+        mac: ShellScript.() -> String = { "Not implemented!" },
+        linux: ShellScript.() -> String = { "Not implemented!" },
+        windows: ShellScript.() -> String = { "Not implemented!" }
+    ): String {
+        val osName = System.getProperty("os.name")
+        return when {
+            osName.contains("Mac") -> this.mac()
+            osName.contains("Windows") -> this.windows()
+            else -> this.linux()
+        }
+    }
+
     /**
      * Change the working directory for subsequent shell commands.
      *


### PR DESCRIPTION
<!-- Thanks for your contribution to *Turtle*! Please check the boxes below before opening the pull request, you do this by putting an x in the box like this: [x]. Thank you! -->

### Checklist
- [X] I've read the [guide for contributing](https://github.com/lordcodes/turtle/blob/master/CONTRIBUTING.md).
- [X] I've checked there are no other [open pull requests](https://github.com/lordcodes/turtle/pulls) for the same change.
- [X] I've formatted all code changes with `./gradlew lcCodeFormat`.
- [X] I've ran all checks with `./gradlew lcChecks`.
- [X] I've updated documentation if needed.
- [x] I've added or updated tests for changes.

### Reason for change
<!-- If the pull request fixes an open issue, please include a link to the issue here. -->
<!-- Please explain why the change is required and the problem it solves. -->

Closes #115

### Description
<!-- Please describe the changes you have made, providing as much detail as possible and including how the changes were tested. -->

- There was already `openFile` that works on Mac and takes a path. This path could actually be a web URL or a file path.
- Added `open` that `openFile` just calls, to avoid changing public API.
- Make `open` run different commands for Mac, Windows and Linux to make it multiplatform.
