### PR TITLE
Stream output as a Sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ shellRun {
 
 Extra commands can easily be added by either calling `command` or by extending `ShellScript`. If you have created a command that you think should be built in, please feel free to [open a PR](https://github.com/lordcodes/turtle/pull/new/master).
 
+### Streaming output
+
+Instead of returning output as a String via `command`, you can instead receive it as a `Sequence` using `commandSequence`. The sequence provides standard output and standard error line-by-line.
+
+```kotlin
+commandSequence("cat", listOf("/path/to/largeFile.txt")).forEach { line ->
+    println(line)
+}
+```
+
 ## Contributing or Help
 
 If you notice any bugs or have a new feature to suggest, please check out the [contributing guide](https://github.com/lordcodes/turtle/blob/master/CONTRIBUTING.md). If you want to make changes, please make sure to discuss anything big before putting in the effort of creating the PR.

--- a/turtle/src/main/kotlin/com/lordcodes/turtle/ShellRunException.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/ShellRunException.kt
@@ -14,5 +14,5 @@ data class ShellRunException(
         "Running shell command failed with code $exitCode"
     } else {
         "Running shell command failed with code $exitCode and message: $errorText"
-    }
+    },
 )

--- a/turtle/src/main/kotlin/com/lordcodes/turtle/ShellRunException.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/ShellRunException.kt
@@ -8,7 +8,11 @@ package com.lordcodes.turtle
  */
 data class ShellRunException(
     val exitCode: Int,
-    val errorText: String,
+    val errorText: String? = null,
 ) : RuntimeException(
-    "Running shell command failed with code $exitCode and message: $errorText",
+    if (errorText == null) {
+        "Running shell command failed with code $exitCode"
+    } else {
+        "Running shell command failed with code $exitCode and message: $errorText"
+    }
 )

--- a/turtle/src/main/kotlin/com/lordcodes/turtle/ShellScript.kt
+++ b/turtle/src/main/kotlin/com/lordcodes/turtle/ShellScript.kt
@@ -101,7 +101,7 @@ class ShellScript constructor(
             "Please use 'commandSequence' instead.",
         replaceWith = ReplaceWith(
             "commandSequence(command, arguments, callbacks)",
-        )
+        ),
     )
     fun commandStreaming(
         command: String,

--- a/turtle/src/test/kotlin/com/lordcodes/turtle/ShellScriptTest.kt
+++ b/turtle/src/test/kotlin/com/lordcodes/turtle/ShellScriptTest.kt
@@ -59,10 +59,17 @@ internal class ShellScriptTest {
     }
 
     @Test
-    fun commandStreaming() {
-        val output = ShellScript().commandStreaming("echo", listOf("Hello world!"))
+    fun commandSequence(@TempDir temporaryFolder: File) {
+        val testFile = File(temporaryFolder, "testFile")
+        testFile.createNewFile()
+        testFile.appendText("Line 1\n")
+        testFile.appendText("Line 2\n")
+        testFile.appendText("Line 3\n")
+        val shell = ShellScript(temporaryFolder)
 
-        assertEquals(output.standardOutput.bufferedReader().readText().trim(), "Hello world!")
+        val sequence = shell.commandSequence("cat", listOf(testFile.name))
+
+        assertEquals(sequence.toList(), listOf("Line 1", "Line 2", "Line 3"))
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for your contribution to *Turtle*! Please check the boxes below before opening the pull request, you do this by putting an x in the box like this: [x]. Thank you! -->

### Checklist
- [x] I've read the [guide for contributing](https://github.com/lordcodes/turtle/blob/master/CONTRIBUTING.md).
- [x] I've checked there are no other [open pull requests](https://github.com/lordcodes/turtle/pulls) for the same change.
- [x] I've formatted all code changes with `./gradlew lcformat`.
- [x] I've ran all checks with `./gradlew lcchecks`.
- [x] I've ran all checks with `./gradlew check`.
- [x] I've updated documentation if needed.
- [x] I've added or updated tests for changes.

### Reason for change
<!-- If the pull request fixes an open issue, please include a link to the issue here. -->
<!-- Please explain why the change is required and the problem it solves. -->

* Closes #200
* Replacement for `commandStreaming` which doesn't function as intended.

### Description
<!-- Please describe the changes you have made, providing as much detail as possible and including how the changes were tested. -->

* `commandStreaming` was intended to allow you to stream output rather than it being read to a String.
* This was so that you could for example read in a large file without causing the process to hang.
* The implementation, however, was waiting for the process before returning the streams for the caller to consume. This meant it didn't actually work.
* This PR adds an alternative function `commandSequence` that returns a Sequence that reads from standard output and standard error line by line.
